### PR TITLE
Fixed MonetaryAccountReferenceTypeAdapter to output proper value. (bunq/sdk_java#49)

### DIFF
--- a/src/main/java/com/bunq/sdk/json/MonetaryAccountReferenceTypeAdapter.java
+++ b/src/main/java/com/bunq/sdk/json/MonetaryAccountReferenceTypeAdapter.java
@@ -19,7 +19,7 @@ public class MonetaryAccountReferenceTypeAdapter extends TypeAdapter<MonetaryAcc
   public void write(JsonWriter out, MonetaryAccountReference value) throws IOException {
     if (value == null || value.isAllFieldNull()) {
       out.nullValue();
-    } else if (value.getPointer() == null) {
+    } else if (value.getLabelMonetaryAccount() != null) {
       LabelMonetaryAccount labelMonetaryAccount = value.getLabelMonetaryAccount();
 
       BunqGsonBuilder.buildDefault().create().toJson(labelMonetaryAccount, LabelMonetaryAccount.class, out);

--- a/src/main/java/com/bunq/sdk/json/MonetaryAccountReferenceTypeAdapter.java
+++ b/src/main/java/com/bunq/sdk/json/MonetaryAccountReferenceTypeAdapter.java
@@ -17,8 +17,12 @@ public class MonetaryAccountReferenceTypeAdapter extends TypeAdapter<MonetaryAcc
 
   @Override
   public void write(JsonWriter out, MonetaryAccountReference value) throws IOException {
-    if (value == null || value.getPointer() == null) {
+    if (value == null || value.isAllFieldNull()) {
       out.nullValue();
+    } else if (value.getPointer() == null) {
+      LabelMonetaryAccount labelMonetaryAccount = value.getLabelMonetaryAccount();
+
+      BunqGsonBuilder.buildDefault().create().toJson(labelMonetaryAccount, LabelMonetaryAccount.class, out);
     } else {
       Pointer pointer = value.getPointer();
 

--- a/src/test/java/com/bunq/sdk/model/generated/endpoint/PaymentTest.java
+++ b/src/test/java/com/bunq/sdk/model/generated/endpoint/PaymentTest.java
@@ -28,17 +28,30 @@ public class PaymentTest extends BunqSdkTestBase {
   private static final int paymentIdwithGeolocation = Config.getPaymentIdWithGeolocation();
   private static final Pointer counterPartyAliasOther = Config.getCounterPartyAliasOther();
   private static final Pointer counterPartyAliasSelf = Config.getCounterPartyAliasSelf();
-
   private static final ApiContext apiContext = getApiContext();
 
+  /**
+   * Payment field value constants.
+   */
   private static final String AMOUNT_EUR = "0.01";
   private static final String CURRENCY = "EUR";
   private static final String PAYMENT_DESCRIPTION = "Java test Payment";
-  private static final int PAGE_SIZE = 200;
+  private static final int PAGE_SIZE = 100;
 
+  /**
+   * Number constants.
+   */
   private static final int NUMBER_ZERO = 0;
 
+  /**
+   * Comparison constants.
+   */
   private static final int COMPARE_EQUAL = 0;
+
+  /**
+   * String constants.
+   */
+  private static final String STRING_NULL = "null";
 
   /**
    * Tests making a payment to another sandbox user
@@ -89,6 +102,7 @@ public class PaymentTest extends BunqSdkTestBase {
     for (Payment payment : allPayment) {
       Assert.assertNotNull(payment.getCounterpartyAlias());
       Assert.assertFalse(payment.getCounterpartyAlias().isAllFieldNull());
+      Assert.assertNotEquals(payment.getCounterpartyAlias().toString(), STRING_NULL);
     }
   }
 
@@ -100,7 +114,6 @@ public class PaymentTest extends BunqSdkTestBase {
 
     Assert.assertNotNull(payment.getGeolocation());
     Assert.assertFalse(payment.getGeolocation().isAllFieldNull());
-
   }
 
 }

--- a/src/test/java/com/bunq/sdk/model/generated/endpoint/PaymentTest.java
+++ b/src/test/java/com/bunq/sdk/model/generated/endpoint/PaymentTest.java
@@ -90,7 +90,9 @@ public class PaymentTest extends BunqSdkTestBase {
       Assert.assertNotNull(payment.getCounterpartyAlias());
       Assert.assertFalse(payment.getCounterpartyAlias().isAllFieldNull());
     }
+  }
 
+  @Test
   public void getPaymentWithGeolocationTest() {
     Assume.assumeFalse(Integer.compare(paymentIdwithGeolocation, NUMBER_ZERO) == COMPARE_EQUAL);
 


### PR DESCRIPTION
[//]: # (Thanks for opening this pull request! Before you proceed please make sure that you have an issue that explains what this pull request will do.
         Make sure that all your commits link to this issue e.g. "My commit. \(bunq/sdk_java#<issue nr>\)".
         If this pull request is changing files that are located in "com.bunq.sdk.model.generated" then this pull request will be closed as these files must/can only be changed on bunq's side.)
         
## This PR closes/fixes the following issues:
[//]: # (If for some reason your pull request does not require a test case you can just mark this box as checked and explain why it does not require a test case.)
 - Closes bunq/sdk_java#49
    - [x] Tested
