### PR TITLE
splitted Payment into a endpoint and model structure

### DIFF
--- a/src/main/java/com/bunq/sdk/context/BunqContext.java
+++ b/src/main/java/com/bunq/sdk/context/BunqContext.java
@@ -7,7 +7,7 @@ public final class BunqContext {
   /**
    * Error constatns.
    */
-  private static final String ERROR_API_CONTEXT_HAS_NOT_BEEN_SET = "Api context has not been set";
+  public static final String ERROR_API_CONTEXT_HAS_NOT_BEEN_SET = "Api context has not been set";
   private static final String ERROR_USER_CONTEXT_HAS_NOT_BEEN_SET = "UserContext has not been set";
 
   private static ApiContext apiContext;

--- a/src/main/java/com/bunq/sdk/model/core/BunqEndpoint.java
+++ b/src/main/java/com/bunq/sdk/model/core/BunqEndpoint.java
@@ -1,0 +1,177 @@
+package com.bunq.sdk.model.core;
+
+import com.bunq.sdk.context.ApiContext;
+import com.bunq.sdk.context.BunqContext;
+import com.bunq.sdk.context.UserContext;
+import com.bunq.sdk.exception.BunqException;
+import com.bunq.sdk.http.ApiClient;
+import com.bunq.sdk.http.BunqResponse;
+import com.bunq.sdk.http.BunqResponseRaw;
+import com.bunq.sdk.http.Pagination;
+import com.bunq.sdk.json.BunqGsonBuilder;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.stream.JsonReader;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+abstract public class BunqEndpoint<T extends BunqModel> {
+
+  /**
+   * Field constants.
+   */
+  private static final String FIELD_RESPONSE = "Response";
+  private static final String FIELD_ID = "Id";
+  private static final String FIELD_UUID = "Uuid";
+  private static final String FIELD_PAGINATION = "Pagination";
+
+  /**
+   * Index of the very first item in an array.
+   */
+  private static final int INDEX_FIRST = 0;
+
+  /**
+   * Gson builder for serialization.
+   */
+  protected final Gson gson = BunqGsonBuilder.buildDefault().create();
+  private final ApiContext apiContext;
+  private final UserContext userContext;
+  private final Class<T> type;
+
+  protected BunqEndpoint(ApiContext apiContext, Class<T> type) {
+    if(apiContext==null) {
+      throw new BunqException(BunqContext.ERROR_API_CONTEXT_HAS_NOT_BEEN_SET);
+    }
+    this.type = Objects.requireNonNull(type);
+    this.apiContext = apiContext;
+    this.userContext = new UserContext(this.apiContext.getSessionContext().getUserId());
+    this.userContext.initMainMonetaryAccount();
+  }
+
+  protected ApiClient getApiClient() {
+    return new ApiClient(getApiContext());
+  }
+
+  protected T fromJsonReader(JsonReader reader) {
+    return gson.fromJson(reader,type);
+  }
+
+  /**
+   * De-serializes an object from a JSON format specific to Installation and SessionServer.
+   */
+  protected BunqResponse<T> fromJsonArrayNested(BunqResponseRaw responseRaw) {
+    String json = new String(responseRaw.getBodyBytes());
+    JsonObject values = this.gson.fromJson(json, JsonObject.class);
+    JsonArray jsonArrayNested = values.getAsJsonArray(FIELD_RESPONSE);
+    T responseValue = this.gson.fromJson(jsonArrayNested, this.type);
+    return new BunqResponse<>(responseValue, responseRaw.getHeaders());
+  }
+
+  /**
+   * De-serializes an ID object and returns its integer value.
+   */
+  protected BunqResponse<Integer> processForId(BunqResponseRaw responseRaw) {
+    JsonObject responseItemObject = getResponseItemObject(responseRaw);
+    JsonObject responseItemObjectUnwrapped = getWrappedContent(responseItemObject, FIELD_ID);
+    Integer responseValue = this.gson.fromJson(responseItemObjectUnwrapped, Id.class).getId();
+    return new BunqResponse<>(responseValue, responseRaw.getHeaders());
+  }
+
+  private JsonObject getResponseItemObject(BunqResponseRaw responseRaw) {
+    JsonObject responseItemObject = deserializeResponseObject(responseRaw);
+    return responseItemObject.getAsJsonArray(FIELD_RESPONSE).get(INDEX_FIRST).getAsJsonObject();
+  }
+
+  private JsonObject getWrappedContent(JsonObject json, String wrapper) {
+    return json.getAsJsonObject(wrapper);
+  }
+
+  /**
+   * De-serialize an object from JSON.
+   */
+  protected BunqResponse<T> fromJson(BunqResponseRaw responseRaw,
+      String wrapper) {
+    JsonObject responseItemObject = getResponseItemObject(responseRaw);
+    JsonObject responseItemObjectUnwrapped = getWrappedContent(responseItemObject, wrapper);
+    T responseValue = this.gson.fromJson(responseItemObjectUnwrapped, this.type);
+
+    return new BunqResponse<>(responseValue, responseRaw.getHeaders());
+  }
+
+  protected BunqResponse<T> fromJson(BunqResponseRaw responseRaw) {
+    JsonObject responseItemObject = getResponseItemObject(responseRaw);
+    T responseValue = this.gson.fromJson(responseItemObject, this.type);
+    return new BunqResponse<>(responseValue, responseRaw.getHeaders());
+  }
+
+  /**
+   * De-serializes a list from JSON.
+   */
+  protected BunqResponse<List<T>> fromJsonList(BunqResponseRaw responseRaw,String wrapper) {
+    JsonObject responseObject = deserializeResponseObject(responseRaw);
+    JsonArray response = responseObject.getAsJsonArray(FIELD_RESPONSE);
+    List<T> list = new ArrayList<>();
+
+    for (JsonElement responseItemWrapped : response) {
+      JsonObject responseItemObject = getWrappedContent(responseItemWrapped.getAsJsonObject(),
+          wrapper);
+      list.add(this.gson.fromJson(responseItemObject, this.type));
+    }
+
+    JsonElement paginationObject = responseObject.get(FIELD_PAGINATION);
+    Pagination pagination = this.gson.fromJson(paginationObject, Pagination.class);
+
+    return new BunqResponse<>(list, responseRaw.getHeaders(), pagination);
+  }
+
+  protected BunqResponse<List<T>> fromJsonList(BunqResponseRaw responseRaw) {
+    JsonObject responseObject = deserializeResponseObject(responseRaw);
+    JsonArray response = responseObject.getAsJsonArray(FIELD_RESPONSE);
+    List<T> objects = new ArrayList<>();
+
+    for (JsonElement responseItem : response) {
+      objects.add(this.gson.fromJson(responseItem, this.type));
+    }
+
+    JsonElement paginationObject = responseObject.get(FIELD_PAGINATION);
+    Pagination pagination = gson.fromJson(paginationObject, Pagination.class);
+
+    return new BunqResponse<>(objects, responseRaw.getHeaders(), pagination);
+  }
+
+  private JsonObject deserializeResponseObject(BunqResponseRaw responseRaw) {
+    String json = new String(responseRaw.getBodyBytes());
+    return this.gson.fromJson(json, JsonObject.class);
+  }
+
+  /**
+   * De-serializes an UUID object and returns its string value.
+   */
+  protected BunqResponse<String> processForUuid(BunqResponseRaw responseRaw) {
+    JsonObject responseItemObject = getResponseItemObject(responseRaw);
+    JsonObject responseItemObjectUnwrapped = getWrappedContent(responseItemObject, FIELD_UUID);
+    String responseValue = this.gson.fromJson(responseItemObjectUnwrapped, Uuid.class).getUuid();
+
+    return new BunqResponse<>(responseValue, responseRaw.getHeaders());
+  }
+
+  protected ApiContext getApiContext() {
+    return this.apiContext;
+  }
+
+  protected Integer determineUserId() {
+    return this.userContext.getUserId();
+  }
+
+  protected Integer determineMonetaryAccountId(Integer id) {
+    if (id == null) {
+      return this.userContext.getPrimaryMonetaryAccountBank().getId();
+    } else {
+      return id;
+    }
+  }
+}

--- a/src/main/java/com/bunq/sdk/model/generated/endpoint/Payment.java
+++ b/src/main/java/com/bunq/sdk/model/generated/endpoint/Payment.java
@@ -1,8 +1,11 @@
 package com.bunq.sdk.model.generated.endpoint;
 
+import com.bunq.sdk.context.ApiContext;
+import com.bunq.sdk.context.BunqContext;
 import com.bunq.sdk.http.ApiClient;
 import com.bunq.sdk.http.BunqResponse;
 import com.bunq.sdk.http.BunqResponseRaw;
+import com.bunq.sdk.model.core.BunqEndpoint;
 import com.bunq.sdk.model.core.BunqModel;
 import com.bunq.sdk.model.core.MonetaryAccountReference;
 import com.bunq.sdk.model.generated.object.Address;
@@ -26,7 +29,7 @@ import java.util.Map;
  * received by the counter-party as part of the Payment. You can also retrieve a single Payment
  * or all executed Payments of a specific monetary account.
  */
-public class Payment extends BunqModel {
+public class Payment extends BunqEndpoint<com.bunq.sdk.model.generated.object.Payment> {
 
   /**
    * Endpoint constants.
@@ -49,181 +52,13 @@ public class Payment extends BunqModel {
    */
   protected static final String OBJECT_TYPE_GET = "Payment";
 
-  /**
-   * The id of the created Payment.
-   */
-  @Expose
-  @SerializedName("id")
-  private Integer id;
+  public Payment() {
+    this(BunqContext.getApiContext());
+  }
 
-  /**
-   * The timestamp when the Payment was done.
-   */
-  @Expose
-  @SerializedName("created")
-  private String created;
-
-  /**
-   * The timestamp when the Payment was last updated (will be updated when chat messages are
-   * received).
-   */
-  @Expose
-  @SerializedName("updated")
-  private String updated;
-
-  /**
-   * The id of the MonetaryAccount the Payment was made to or from (depending on whether this is
-   * an incoming or outgoing Payment).
-   */
-  @Expose
-  @SerializedName("monetary_account_id")
-  private Integer monetaryAccountId;
-
-  /**
-   * The Amount transferred by the Payment. Will be negative for outgoing Payments and positive
-   * for incoming Payments (relative to the MonetaryAccount indicated by monetary_account_id).
-   */
-  @Expose
-  @SerializedName("amount")
-  private Amount amount;
-
-  /**
-   * The LabelMonetaryAccount containing the public information of 'this' (party) side of the
-   * Payment.
-   */
-  @Expose
-  @SerializedName("alias")
-  private MonetaryAccountReference alias;
-
-  /**
-   * The LabelMonetaryAccount containing the public information of the other (counterparty) side
-   * of the Payment.
-   */
-  @Expose
-  @SerializedName("counterparty_alias")
-  private MonetaryAccountReference counterpartyAlias;
-
-  /**
-   * The description for the Payment. Maximum 140 characters for Payments to external IBANs, 9000
-   * characters for Payments to only other bunq MonetaryAccounts.
-   */
-  @Expose
-  @SerializedName("description")
-  private String description;
-
-  /**
-   * The type of Payment, can be BUNQ, EBA_SCT, EBA_SDD, IDEAL, SWIFT or FIS (card).
-   */
-  @Expose
-  @SerializedName("type")
-  private String type;
-
-  /**
-   * The sub-type of the Payment, can be PAYMENT, WITHDRAWAL, REVERSAL, REQUEST, BILLING, SCT, SDD
-   * or NLO.
-   */
-  @Expose
-  @SerializedName("sub_type")
-  private String subType;
-
-  /**
-   * The status of the bunq.to payment.
-   */
-  @Expose
-  @SerializedName("bunqto_status")
-  private String bunqtoStatus;
-
-  /**
-   * The sub status of the bunq.to payment.
-   */
-  @Expose
-  @SerializedName("bunqto_sub_status")
-  private String bunqtoSubStatus;
-
-  /**
-   * The status of the bunq.to payment.
-   */
-  @Expose
-  @SerializedName("bunqto_share_url")
-  private String bunqtoShareUrl;
-
-  /**
-   * When bunq.to payment is about to expire.
-   */
-  @Expose
-  @SerializedName("bunqto_expiry")
-  private String bunqtoExpiry;
-
-  /**
-   * The timestamp of when the bunq.to payment was responded to.
-   */
-  @Expose
-  @SerializedName("bunqto_time_responded")
-  private String bunqtoTimeResponded;
-
-  /**
-   * The Attachments attached to the Payment.
-   */
-  @Expose
-  @SerializedName("attachment")
-  private List<AttachmentMonetaryAccountPayment> attachment;
-
-  /**
-   * Optional data included with the Payment specific to the merchant.
-   */
-  @Expose
-  @SerializedName("merchant_reference")
-  private String merchantReference;
-
-  /**
-   * The id of the PaymentBatch if this Payment was part of one.
-   */
-  @Expose
-  @SerializedName("batch_id")
-  private Integer batchId;
-
-  /**
-   * The id of the JobScheduled if the Payment was scheduled.
-   */
-  @Expose
-  @SerializedName("scheduled_id")
-  private Integer scheduledId;
-
-  /**
-   * A shipping Address provided with the Payment, currently unused.
-   */
-  @Expose
-  @SerializedName("address_shipping")
-  private Address addressShipping;
-
-  /**
-   * A billing Address provided with the Payment, currently unused.
-   */
-  @Expose
-  @SerializedName("address_billing")
-  private Address addressBilling;
-
-  /**
-   * The Geolocation where the Payment was done from.
-   */
-  @Expose
-  @SerializedName("geolocation")
-  private Geolocation geolocation;
-
-  /**
-   * Whether or not chat messages are allowed.
-   */
-  @Expose
-  @SerializedName("allow_chat")
-  private Boolean allowChat;
-
-  /**
-   * The reference to the object used for split the bill. Can be RequestInquiry or
-   * RequestInquiryBatch
-   */
-  @Expose
-  @SerializedName("request_reference_split_the_bill")
-  private List<RequestInquiryReference> requestReferenceSplitTheBill;
+  public Payment(ApiContext apiContext) {
+    super(apiContext, com.bunq.sdk.model.generated.object.Payment.class);
+  }
 
   /**
    * Create a new Payment.
@@ -239,8 +74,8 @@ public class Payment extends BunqModel {
    * @param merchantReference Optional data to be included with the Payment specific to the
    * merchant.
    */
-  public static BunqResponse<Integer> create(Amount amount, Pointer counterpartyAlias, String description, Integer monetaryAccountId, List<AttachmentMonetaryAccountPayment> attachment, String merchantReference, Map<String, String> customHeaders) {
-    ApiClient apiClient = new ApiClient(getApiContext());
+  public BunqResponse<Integer> create(Amount amount, Pointer counterpartyAlias, String description, Integer monetaryAccountId, List<AttachmentMonetaryAccountPayment> attachment, String merchantReference, Map<String, String> customHeaders) {
+    ApiClient apiClient = getApiClient();
 
     if (customHeaders == null) {
       customHeaders = new HashMap<>();
@@ -259,460 +94,78 @@ public class Payment extends BunqModel {
     return processForId(responseRaw);
   }
 
-  public static BunqResponse<Integer> create() {
+  public BunqResponse<Integer> create() {
     return create(null, null, null, null, null, null, null);
   }
 
-  public static BunqResponse<Integer> create(Amount amount) {
+  public BunqResponse<Integer> create(Amount amount) {
     return create(amount, null, null, null, null, null, null);
   }
 
-  public static BunqResponse<Integer> create(Amount amount, Pointer counterpartyAlias) {
+  public BunqResponse<Integer> create(Amount amount, Pointer counterpartyAlias) {
     return create(amount, counterpartyAlias, null, null, null, null, null);
   }
 
-  public static BunqResponse<Integer> create(Amount amount, Pointer counterpartyAlias, String description) {
+  public BunqResponse<Integer> create(Amount amount, Pointer counterpartyAlias, String description) {
     return create(amount, counterpartyAlias, description, null, null, null, null);
   }
 
-  public static BunqResponse<Integer> create(Amount amount, Pointer counterpartyAlias, String description, Integer monetaryAccountId) {
+  public BunqResponse<Integer> create(Amount amount, Pointer counterpartyAlias, String description, Integer monetaryAccountId) {
     return create(amount, counterpartyAlias, description, monetaryAccountId, null, null, null);
   }
 
-  public static BunqResponse<Integer> create(Amount amount, Pointer counterpartyAlias, String description, Integer monetaryAccountId, List<AttachmentMonetaryAccountPayment> attachment) {
+  public BunqResponse<Integer> create(Amount amount, Pointer counterpartyAlias, String description, Integer monetaryAccountId, List<AttachmentMonetaryAccountPayment> attachment) {
     return create(amount, counterpartyAlias, description, monetaryAccountId, attachment, null, null);
   }
 
-  public static BunqResponse<Integer> create(Amount amount, Pointer counterpartyAlias, String description, Integer monetaryAccountId, List<AttachmentMonetaryAccountPayment> attachment, String merchantReference) {
+  public BunqResponse<Integer> create(Amount amount, Pointer counterpartyAlias, String description, Integer monetaryAccountId, List<AttachmentMonetaryAccountPayment> attachment, String merchantReference) {
     return create(amount, counterpartyAlias, description, monetaryAccountId, attachment, merchantReference, null);
   }
 
   /**
    * Get a specific previous Payment.
    */
-  public static BunqResponse<Payment> get(Integer paymentId, Integer monetaryAccountId, Map<String, String> params, Map<String, String> customHeaders) {
+  public BunqResponse<com.bunq.sdk.model.generated.object.Payment> get(Integer paymentId, Integer monetaryAccountId, Map<String, String> params, Map<String, String> customHeaders) {
     ApiClient apiClient = new ApiClient(getApiContext());
     BunqResponseRaw responseRaw = apiClient.get(String.format(ENDPOINT_URL_READ, determineUserId(), determineMonetaryAccountId(monetaryAccountId), paymentId), params, customHeaders);
 
-    return fromJson(Payment.class, responseRaw, OBJECT_TYPE_GET);
+    return fromJson(responseRaw, OBJECT_TYPE_GET);
   }
 
-  public static BunqResponse<Payment> get() {
+  public BunqResponse<com.bunq.sdk.model.generated.object.Payment> get() {
     return get(null, null, null, null);
   }
 
-  public static BunqResponse<Payment> get(Integer paymentId) {
+  public BunqResponse<com.bunq.sdk.model.generated.object.Payment> get(Integer paymentId) {
     return get(paymentId, null, null, null);
   }
 
-  public static BunqResponse<Payment> get(Integer paymentId, Integer monetaryAccountId) {
+  public BunqResponse<com.bunq.sdk.model.generated.object.Payment> get(Integer paymentId, Integer monetaryAccountId) {
     return get(paymentId, monetaryAccountId, null, null);
   }
 
-  public static BunqResponse<Payment> get(Integer paymentId, Integer monetaryAccountId, Map<String, String> params) {
+  public BunqResponse<com.bunq.sdk.model.generated.object.Payment> get(Integer paymentId, Integer monetaryAccountId, Map<String, String> params) {
     return get(paymentId, monetaryAccountId, params, null);
   }
 
   /**
    * Get a listing of all Payments performed on a given MonetaryAccount (incoming and outgoing).
    */
-  public static BunqResponse<List<Payment>> list(Integer monetaryAccountId, Map<String, String> params, Map<String, String> customHeaders) {
-    ApiClient apiClient = new ApiClient(getApiContext());
+  public BunqResponse<List<com.bunq.sdk.model.generated.object.Payment>> list(Integer monetaryAccountId, Map<String, String> params, Map<String, String> customHeaders) {
+    ApiClient apiClient = getApiClient();
     BunqResponseRaw responseRaw = apiClient.get(String.format(ENDPOINT_URL_LISTING, determineUserId(), determineMonetaryAccountId(monetaryAccountId)), params, customHeaders);
-
-    return fromJsonList(Payment.class, responseRaw, OBJECT_TYPE_GET);
+    return fromJsonList(responseRaw, OBJECT_TYPE_GET);
   }
 
-  public static BunqResponse<List<Payment>> list() {
+  public BunqResponse<List<com.bunq.sdk.model.generated.object.Payment>> list() {
     return list(null, null, null);
   }
 
-  public static BunqResponse<List<Payment>> list(Integer monetaryAccountId) {
+  public BunqResponse<List<com.bunq.sdk.model.generated.object.Payment>> list(Integer monetaryAccountId) {
     return list(monetaryAccountId, null, null);
   }
 
-  public static BunqResponse<List<Payment>> list(Integer monetaryAccountId, Map<String, String> params) {
+  public BunqResponse<List<com.bunq.sdk.model.generated.object.Payment>> list(Integer monetaryAccountId, Map<String, String> params) {
     return list(monetaryAccountId, params, null);
   }
-
-  /**
-   * The id of the created Payment.
-   */
-  public Integer getId() {
-    return this.id;
-  }
-
-  public void setId(Integer id) {
-    this.id = id;
-  }
-
-  /**
-   * The timestamp when the Payment was done.
-   */
-  public String getCreated() {
-    return this.created;
-  }
-
-  public void setCreated(String created) {
-    this.created = created;
-  }
-
-  /**
-   * The timestamp when the Payment was last updated (will be updated when chat messages are
-   * received).
-   */
-  public String getUpdated() {
-    return this.updated;
-  }
-
-  public void setUpdated(String updated) {
-    this.updated = updated;
-  }
-
-  /**
-   * The id of the MonetaryAccount the Payment was made to or from (depending on whether this is
-   * an incoming or outgoing Payment).
-   */
-  public Integer getMonetaryAccountId() {
-    return this.monetaryAccountId;
-  }
-
-  public void setMonetaryAccountId(Integer monetaryAccountId) {
-    this.monetaryAccountId = monetaryAccountId;
-  }
-
-  /**
-   * The Amount transferred by the Payment. Will be negative for outgoing Payments and positive
-   * for incoming Payments (relative to the MonetaryAccount indicated by monetary_account_id).
-   */
-  public Amount getAmount() {
-    return this.amount;
-  }
-
-  public void setAmount(Amount amount) {
-    this.amount = amount;
-  }
-
-  /**
-   * The LabelMonetaryAccount containing the public information of 'this' (party) side of the
-   * Payment.
-   */
-  public MonetaryAccountReference getAlias() {
-    return this.alias;
-  }
-
-  public void setAlias(MonetaryAccountReference alias) {
-    this.alias = alias;
-  }
-
-  /**
-   * The LabelMonetaryAccount containing the public information of the other (counterparty) side
-   * of the Payment.
-   */
-  public MonetaryAccountReference getCounterpartyAlias() {
-    return this.counterpartyAlias;
-  }
-
-  public void setCounterpartyAlias(MonetaryAccountReference counterpartyAlias) {
-    this.counterpartyAlias = counterpartyAlias;
-  }
-
-  /**
-   * The description for the Payment. Maximum 140 characters for Payments to external IBANs, 9000
-   * characters for Payments to only other bunq MonetaryAccounts.
-   */
-  public String getDescription() {
-    return this.description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  /**
-   * The type of Payment, can be BUNQ, EBA_SCT, EBA_SDD, IDEAL, SWIFT or FIS (card).
-   */
-  public String getType() {
-    return this.type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  /**
-   * The sub-type of the Payment, can be PAYMENT, WITHDRAWAL, REVERSAL, REQUEST, BILLING, SCT, SDD
-   * or NLO.
-   */
-  public String getSubType() {
-    return this.subType;
-  }
-
-  public void setSubType(String subType) {
-    this.subType = subType;
-  }
-
-  /**
-   * The status of the bunq.to payment.
-   */
-  public String getBunqtoStatus() {
-    return this.bunqtoStatus;
-  }
-
-  public void setBunqtoStatus(String bunqtoStatus) {
-    this.bunqtoStatus = bunqtoStatus;
-  }
-
-  /**
-   * The sub status of the bunq.to payment.
-   */
-  public String getBunqtoSubStatus() {
-    return this.bunqtoSubStatus;
-  }
-
-  public void setBunqtoSubStatus(String bunqtoSubStatus) {
-    this.bunqtoSubStatus = bunqtoSubStatus;
-  }
-
-  /**
-   * The status of the bunq.to payment.
-   */
-  public String getBunqtoShareUrl() {
-    return this.bunqtoShareUrl;
-  }
-
-  public void setBunqtoShareUrl(String bunqtoShareUrl) {
-    this.bunqtoShareUrl = bunqtoShareUrl;
-  }
-
-  /**
-   * When bunq.to payment is about to expire.
-   */
-  public String getBunqtoExpiry() {
-    return this.bunqtoExpiry;
-  }
-
-  public void setBunqtoExpiry(String bunqtoExpiry) {
-    this.bunqtoExpiry = bunqtoExpiry;
-  }
-
-  /**
-   * The timestamp of when the bunq.to payment was responded to.
-   */
-  public String getBunqtoTimeResponded() {
-    return this.bunqtoTimeResponded;
-  }
-
-  public void setBunqtoTimeResponded(String bunqtoTimeResponded) {
-    this.bunqtoTimeResponded = bunqtoTimeResponded;
-  }
-
-  /**
-   * The Attachments attached to the Payment.
-   */
-  public List<AttachmentMonetaryAccountPayment> getAttachment() {
-    return this.attachment;
-  }
-
-  public void setAttachment(List<AttachmentMonetaryAccountPayment> attachment) {
-    this.attachment = attachment;
-  }
-
-  /**
-   * Optional data included with the Payment specific to the merchant.
-   */
-  public String getMerchantReference() {
-    return this.merchantReference;
-  }
-
-  public void setMerchantReference(String merchantReference) {
-    this.merchantReference = merchantReference;
-  }
-
-  /**
-   * The id of the PaymentBatch if this Payment was part of one.
-   */
-  public Integer getBatchId() {
-    return this.batchId;
-  }
-
-  public void setBatchId(Integer batchId) {
-    this.batchId = batchId;
-  }
-
-  /**
-   * The id of the JobScheduled if the Payment was scheduled.
-   */
-  public Integer getScheduledId() {
-    return this.scheduledId;
-  }
-
-  public void setScheduledId(Integer scheduledId) {
-    this.scheduledId = scheduledId;
-  }
-
-  /**
-   * A shipping Address provided with the Payment, currently unused.
-   */
-  public Address getAddressShipping() {
-    return this.addressShipping;
-  }
-
-  public void setAddressShipping(Address addressShipping) {
-    this.addressShipping = addressShipping;
-  }
-
-  /**
-   * A billing Address provided with the Payment, currently unused.
-   */
-  public Address getAddressBilling() {
-    return this.addressBilling;
-  }
-
-  public void setAddressBilling(Address addressBilling) {
-    this.addressBilling = addressBilling;
-  }
-
-  /**
-   * The Geolocation where the Payment was done from.
-   */
-  public Geolocation getGeolocation() {
-    return this.geolocation;
-  }
-
-  public void setGeolocation(Geolocation geolocation) {
-    this.geolocation = geolocation;
-  }
-
-  /**
-   * Whether or not chat messages are allowed.
-   */
-  public Boolean getAllowChat() {
-    return this.allowChat;
-  }
-
-  public void setAllowChat(Boolean allowChat) {
-    this.allowChat = allowChat;
-  }
-
-  /**
-   * The reference to the object used for split the bill. Can be RequestInquiry or
-   * RequestInquiryBatch
-   */
-  public List<RequestInquiryReference> getRequestReferenceSplitTheBill() {
-    return this.requestReferenceSplitTheBill;
-  }
-
-  public void setRequestReferenceSplitTheBill(List<RequestInquiryReference> requestReferenceSplitTheBill) {
-    this.requestReferenceSplitTheBill = requestReferenceSplitTheBill;
-  }
-
-  /**
-   */
-  public boolean isAllFieldNull() {
-    if (this.id != null) {
-      return false;
-    }
-
-    if (this.created != null) {
-      return false;
-    }
-
-    if (this.updated != null) {
-      return false;
-    }
-
-    if (this.monetaryAccountId != null) {
-      return false;
-    }
-
-    if (this.amount != null) {
-      return false;
-    }
-
-    if (this.alias != null) {
-      return false;
-    }
-
-    if (this.counterpartyAlias != null) {
-      return false;
-    }
-
-    if (this.description != null) {
-      return false;
-    }
-
-    if (this.type != null) {
-      return false;
-    }
-
-    if (this.subType != null) {
-      return false;
-    }
-
-    if (this.bunqtoStatus != null) {
-      return false;
-    }
-
-    if (this.bunqtoSubStatus != null) {
-      return false;
-    }
-
-    if (this.bunqtoShareUrl != null) {
-      return false;
-    }
-
-    if (this.bunqtoExpiry != null) {
-      return false;
-    }
-
-    if (this.bunqtoTimeResponded != null) {
-      return false;
-    }
-
-    if (this.attachment != null) {
-      return false;
-    }
-
-    if (this.merchantReference != null) {
-      return false;
-    }
-
-    if (this.batchId != null) {
-      return false;
-    }
-
-    if (this.scheduledId != null) {
-      return false;
-    }
-
-    if (this.addressShipping != null) {
-      return false;
-    }
-
-    if (this.addressBilling != null) {
-      return false;
-    }
-
-    if (this.geolocation != null) {
-      return false;
-    }
-
-    if (this.allowChat != null) {
-      return false;
-    }
-
-    if (this.requestReferenceSplitTheBill != null) {
-      return false;
-    }
-
-    return true;
-  }
-
-  /**
-   */
-  public static Payment fromJsonReader(JsonReader reader) {
-    return fromJsonReader(Payment.class, reader);
-  }
-
 }

--- a/src/main/java/com/bunq/sdk/model/generated/object/Payment.java
+++ b/src/main/java/com/bunq/sdk/model/generated/object/Payment.java
@@ -1,0 +1,579 @@
+package com.bunq.sdk.model.generated.object;
+
+import com.bunq.sdk.http.ApiClient;
+import com.bunq.sdk.http.BunqResponse;
+import com.bunq.sdk.http.BunqResponseRaw;
+import com.bunq.sdk.model.core.BunqModel;
+import com.bunq.sdk.model.core.MonetaryAccountReference;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Using Payment, you can send payments to bunq and non-bunq users from your bunq
+ * MonetaryAccounts. This can be done using bunq Aliases or IBAN Aliases. When transferring
+ * money to other bunq MonetaryAccounts you can also refer to Attachments. These will be
+ * received by the counter-party as part of the Payment. You can also retrieve a single Payment
+ * or all executed Payments of a specific monetary account.
+ */
+public class Payment extends BunqModel {
+  /**
+   * The id of the created Payment.
+   */
+  @Expose
+  @SerializedName("id")
+  private Integer id;
+
+  /**
+   * The timestamp when the Payment was done.
+   */
+  @Expose
+  @SerializedName("created")
+  private String created;
+
+  /**
+   * The timestamp when the Payment was last updated (will be updated when chat messages are
+   * received).
+   */
+  @Expose
+  @SerializedName("updated")
+  private String updated;
+
+  /**
+   * The id of the MonetaryAccount the Payment was made to or from (depending on whether this is
+   * an incoming or outgoing Payment).
+   */
+  @Expose
+  @SerializedName("monetary_account_id")
+  private Integer monetaryAccountId;
+
+  /**
+   * The Amount transferred by the Payment. Will be negative for outgoing Payments and positive
+   * for incoming Payments (relative to the MonetaryAccount indicated by monetary_account_id).
+   */
+  @Expose
+  @SerializedName("amount")
+  private Amount amount;
+
+  /**
+   * The LabelMonetaryAccount containing the public information of 'this' (party) side of the
+   * Payment.
+   */
+  @Expose
+  @SerializedName("alias")
+  private MonetaryAccountReference alias;
+
+  /**
+   * The LabelMonetaryAccount containing the public information of the other (counterparty) side
+   * of the Payment.
+   */
+  @Expose
+  @SerializedName("counterparty_alias")
+  private MonetaryAccountReference counterpartyAlias;
+
+  /**
+   * The description for the Payment. Maximum 140 characters for Payments to external IBANs, 9000
+   * characters for Payments to only other bunq MonetaryAccounts.
+   */
+  @Expose
+  @SerializedName("description")
+  private String description;
+
+  /**
+   * The type of Payment, can be BUNQ, EBA_SCT, EBA_SDD, IDEAL, SWIFT or FIS (card).
+   */
+  @Expose
+  @SerializedName("type")
+  private String type;
+
+  /**
+   * The sub-type of the Payment, can be PAYMENT, WITHDRAWAL, REVERSAL, REQUEST, BILLING, SCT, SDD
+   * or NLO.
+   */
+  @Expose
+  @SerializedName("sub_type")
+  private String subType;
+
+  /**
+   * The status of the bunq.to payment.
+   */
+  @Expose
+  @SerializedName("bunqto_status")
+  private String bunqtoStatus;
+
+  /**
+   * The sub status of the bunq.to payment.
+   */
+  @Expose
+  @SerializedName("bunqto_sub_status")
+  private String bunqtoSubStatus;
+
+  /**
+   * The status of the bunq.to payment.
+   */
+  @Expose
+  @SerializedName("bunqto_share_url")
+  private String bunqtoShareUrl;
+
+  /**
+   * When bunq.to payment is about to expire.
+   */
+  @Expose
+  @SerializedName("bunqto_expiry")
+  private String bunqtoExpiry;
+
+  /**
+   * The timestamp of when the bunq.to payment was responded to.
+   */
+  @Expose
+  @SerializedName("bunqto_time_responded")
+  private String bunqtoTimeResponded;
+
+  /**
+   * The Attachments attached to the Payment.
+   */
+  @Expose
+  @SerializedName("attachment")
+  private List<AttachmentMonetaryAccountPayment> attachment;
+
+  /**
+   * Optional data included with the Payment specific to the merchant.
+   */
+  @Expose
+  @SerializedName("merchant_reference")
+  private String merchantReference;
+
+  /**
+   * The id of the PaymentBatch if this Payment was part of one.
+   */
+  @Expose
+  @SerializedName("batch_id")
+  private Integer batchId;
+
+  /**
+   * The id of the JobScheduled if the Payment was scheduled.
+   */
+  @Expose
+  @SerializedName("scheduled_id")
+  private Integer scheduledId;
+
+  /**
+   * A shipping Address provided with the Payment, currently unused.
+   */
+  @Expose
+  @SerializedName("address_shipping")
+  private Address addressShipping;
+
+  /**
+   * A billing Address provided with the Payment, currently unused.
+   */
+  @Expose
+  @SerializedName("address_billing")
+  private Address addressBilling;
+
+  /**
+   * The Geolocation where the Payment was done from.
+   */
+  @Expose
+  @SerializedName("geolocation")
+  private Geolocation geolocation;
+
+  /**
+   * Whether or not chat messages are allowed.
+   */
+  @Expose
+  @SerializedName("allow_chat")
+  private Boolean allowChat;
+
+  /**
+   * The reference to the object used for split the bill. Can be RequestInquiry or
+   * RequestInquiryBatch
+   */
+  @Expose
+  @SerializedName("request_reference_split_the_bill")
+  private List<RequestInquiryReference> requestReferenceSplitTheBill;
+
+  /**
+   * The id of the created Payment.
+   */
+  public Integer getId() {
+    return this.id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  /**
+   * The timestamp when the Payment was done.
+   */
+  public String getCreated() {
+    return this.created;
+  }
+
+  public void setCreated(String created) {
+    this.created = created;
+  }
+
+  /**
+   * The timestamp when the Payment was last updated (will be updated when chat messages are
+   * received).
+   */
+  public String getUpdated() {
+    return this.updated;
+  }
+
+  public void setUpdated(String updated) {
+    this.updated = updated;
+  }
+
+  /**
+   * The id of the MonetaryAccount the Payment was made to or from (depending on whether this is
+   * an incoming or outgoing Payment).
+   */
+  public Integer getMonetaryAccountId() {
+    return this.monetaryAccountId;
+  }
+
+  public void setMonetaryAccountId(Integer monetaryAccountId) {
+    this.monetaryAccountId = monetaryAccountId;
+  }
+
+  /**
+   * The Amount transferred by the Payment. Will be negative for outgoing Payments and positive
+   * for incoming Payments (relative to the MonetaryAccount indicated by monetary_account_id).
+   */
+  public Amount getAmount() {
+    return this.amount;
+  }
+
+  public void setAmount(Amount amount) {
+    this.amount = amount;
+  }
+
+  /**
+   * The LabelMonetaryAccount containing the public information of 'this' (party) side of the
+   * Payment.
+   */
+  public MonetaryAccountReference getAlias() {
+    return this.alias;
+  }
+
+  public void setAlias(MonetaryAccountReference alias) {
+    this.alias = alias;
+  }
+
+  /**
+   * The LabelMonetaryAccount containing the public information of the other (counterparty) side
+   * of the Payment.
+   */
+  public MonetaryAccountReference getCounterpartyAlias() {
+    return this.counterpartyAlias;
+  }
+
+  public void setCounterpartyAlias(MonetaryAccountReference counterpartyAlias) {
+    this.counterpartyAlias = counterpartyAlias;
+  }
+
+  /**
+   * The description for the Payment. Maximum 140 characters for Payments to external IBANs, 9000
+   * characters for Payments to only other bunq MonetaryAccounts.
+   */
+  public String getDescription() {
+    return this.description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  /**
+   * The type of Payment, can be BUNQ, EBA_SCT, EBA_SDD, IDEAL, SWIFT or FIS (card).
+   */
+  public String getType() {
+    return this.type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  /**
+   * The sub-type of the Payment, can be PAYMENT, WITHDRAWAL, REVERSAL, REQUEST, BILLING, SCT, SDD
+   * or NLO.
+   */
+  public String getSubType() {
+    return this.subType;
+  }
+
+  public void setSubType(String subType) {
+    this.subType = subType;
+  }
+
+  /**
+   * The status of the bunq.to payment.
+   */
+  public String getBunqtoStatus() {
+    return this.bunqtoStatus;
+  }
+
+  public void setBunqtoStatus(String bunqtoStatus) {
+    this.bunqtoStatus = bunqtoStatus;
+  }
+
+  /**
+   * The sub status of the bunq.to payment.
+   */
+  public String getBunqtoSubStatus() {
+    return this.bunqtoSubStatus;
+  }
+
+  public void setBunqtoSubStatus(String bunqtoSubStatus) {
+    this.bunqtoSubStatus = bunqtoSubStatus;
+  }
+
+  /**
+   * The status of the bunq.to payment.
+   */
+  public String getBunqtoShareUrl() {
+    return this.bunqtoShareUrl;
+  }
+
+  public void setBunqtoShareUrl(String bunqtoShareUrl) {
+    this.bunqtoShareUrl = bunqtoShareUrl;
+  }
+
+  /**
+   * When bunq.to payment is about to expire.
+   */
+  public String getBunqtoExpiry() {
+    return this.bunqtoExpiry;
+  }
+
+  public void setBunqtoExpiry(String bunqtoExpiry) {
+    this.bunqtoExpiry = bunqtoExpiry;
+  }
+
+  /**
+   * The timestamp of when the bunq.to payment was responded to.
+   */
+  public String getBunqtoTimeResponded() {
+    return this.bunqtoTimeResponded;
+  }
+
+  public void setBunqtoTimeResponded(String bunqtoTimeResponded) {
+    this.bunqtoTimeResponded = bunqtoTimeResponded;
+  }
+
+  /**
+   * The Attachments attached to the Payment.
+   */
+  public List<AttachmentMonetaryAccountPayment> getAttachment() {
+    return this.attachment;
+  }
+
+  public void setAttachment(List<AttachmentMonetaryAccountPayment> attachment) {
+    this.attachment = attachment;
+  }
+
+  /**
+   * Optional data included with the Payment specific to the merchant.
+   */
+  public String getMerchantReference() {
+    return this.merchantReference;
+  }
+
+  public void setMerchantReference(String merchantReference) {
+    this.merchantReference = merchantReference;
+  }
+
+  /**
+   * The id of the PaymentBatch if this Payment was part of one.
+   */
+  public Integer getBatchId() {
+    return this.batchId;
+  }
+
+  public void setBatchId(Integer batchId) {
+    this.batchId = batchId;
+  }
+
+  /**
+   * The id of the JobScheduled if the Payment was scheduled.
+   */
+  public Integer getScheduledId() {
+    return this.scheduledId;
+  }
+
+  public void setScheduledId(Integer scheduledId) {
+    this.scheduledId = scheduledId;
+  }
+
+  /**
+   * A shipping Address provided with the Payment, currently unused.
+   */
+  public Address getAddressShipping() {
+    return this.addressShipping;
+  }
+
+  public void setAddressShipping(Address addressShipping) {
+    this.addressShipping = addressShipping;
+  }
+
+  /**
+   * A billing Address provided with the Payment, currently unused.
+   */
+  public Address getAddressBilling() {
+    return this.addressBilling;
+  }
+
+  public void setAddressBilling(Address addressBilling) {
+    this.addressBilling = addressBilling;
+  }
+
+  /**
+   * The Geolocation where the Payment was done from.
+   */
+  public Geolocation getGeolocation() {
+    return this.geolocation;
+  }
+
+  public void setGeolocation(Geolocation geolocation) {
+    this.geolocation = geolocation;
+  }
+
+  /**
+   * Whether or not chat messages are allowed.
+   */
+  public Boolean getAllowChat() {
+    return this.allowChat;
+  }
+
+  public void setAllowChat(Boolean allowChat) {
+    this.allowChat = allowChat;
+  }
+
+  /**
+   * The reference to the object used for split the bill. Can be RequestInquiry or
+   * RequestInquiryBatch
+   */
+  public List<RequestInquiryReference> getRequestReferenceSplitTheBill() {
+    return this.requestReferenceSplitTheBill;
+  }
+
+  public void setRequestReferenceSplitTheBill(List<RequestInquiryReference> requestReferenceSplitTheBill) {
+    this.requestReferenceSplitTheBill = requestReferenceSplitTheBill;
+  }
+
+  /**
+   */
+  public boolean isAllFieldNull() {
+    if (this.id != null) {
+      return false;
+    }
+
+    if (this.created != null) {
+      return false;
+    }
+
+    if (this.updated != null) {
+      return false;
+    }
+
+    if (this.monetaryAccountId != null) {
+      return false;
+    }
+
+    if (this.amount != null) {
+      return false;
+    }
+
+    if (this.alias != null) {
+      return false;
+    }
+
+    if (this.counterpartyAlias != null) {
+      return false;
+    }
+
+    if (this.description != null) {
+      return false;
+    }
+
+    if (this.type != null) {
+      return false;
+    }
+
+    if (this.subType != null) {
+      return false;
+    }
+
+    if (this.bunqtoStatus != null) {
+      return false;
+    }
+
+    if (this.bunqtoSubStatus != null) {
+      return false;
+    }
+
+    if (this.bunqtoShareUrl != null) {
+      return false;
+    }
+
+    if (this.bunqtoExpiry != null) {
+      return false;
+    }
+
+    if (this.bunqtoTimeResponded != null) {
+      return false;
+    }
+
+    if (this.attachment != null) {
+      return false;
+    }
+
+    if (this.merchantReference != null) {
+      return false;
+    }
+
+    if (this.batchId != null) {
+      return false;
+    }
+
+    if (this.scheduledId != null) {
+      return false;
+    }
+
+    if (this.addressShipping != null) {
+      return false;
+    }
+
+    if (this.addressBilling != null) {
+      return false;
+    }
+
+    if (this.geolocation != null) {
+      return false;
+    }
+
+    if (this.allowChat != null) {
+      return false;
+    }
+
+    if (this.requestReferenceSplitTheBill != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   */
+  public static Payment fromJsonReader(JsonReader reader) {
+    return fromJsonReader(Payment.class, reader);
+  }
+}


### PR DESCRIPTION
red (non-compiling); example splitting the responsibilities of model and endpoint into own hierarchy’s,
this example code for issue #93 

currently due to static methods the sdk/api is limited to single-context use and using it in tests is harder.

this example code is illustrates the following
- separating the model- and endpoint concerns into own hierarchy
- enabling non-static access on the endpoint methods

it is however breaking api, up to some extend it is possible to prevent this, but having model and endpoint concerns in the same package/class (for Payment at least) is not splittable without breaking compatibility