### PR TITLE
minor change in API to enable non-static usage

### DIFF
--- a/src/main/java/com/bunq/sdk/context/BunqContext.java
+++ b/src/main/java/com/bunq/sdk/context/BunqContext.java
@@ -15,8 +15,7 @@ public final class BunqContext {
 
   public static void loadApiContext(ApiContext apiContext) {
     BunqContext.apiContext = apiContext;
-    BunqContext.userContext = apiContext.getSessionContext().initUserContext();
-    BunqContext.userContext.initMainMonetaryAccount();
+    BunqContext.userContext = new UserContext(apiContext);
   }
 
   public static ApiContext getApiContext() {

--- a/src/main/java/com/bunq/sdk/context/BunqContext.java
+++ b/src/main/java/com/bunq/sdk/context/BunqContext.java
@@ -15,7 +15,7 @@ public final class BunqContext {
 
   public static void loadApiContext(ApiContext apiContext) {
     BunqContext.apiContext = apiContext;
-    BunqContext.userContext = new UserContext(apiContext.getSessionContext().getUserId());
+    BunqContext.userContext = apiContext.getSessionContext().initUserContext();
     BunqContext.userContext.initMainMonetaryAccount();
   }
 

--- a/src/main/java/com/bunq/sdk/context/SessionContext.java
+++ b/src/main/java/com/bunq/sdk/context/SessionContext.java
@@ -53,14 +53,10 @@ public class SessionContext implements java.io.Serializable {
   SessionContext(SessionServer sessionServer) {
     this.token = sessionServer.getSessionToken().getToken();
     this.expiryTime = calculateExpiryTime(sessionServer);
-    this.userId = getUserId(sessionServer.getReferencedObject());
-  }
-
-  private Integer getUserId(BunqModel user) {
-    if (user instanceof UserPerson) {
-      return ((UserPerson) user).getId();
-    } else if (user instanceof UserCompany) {
-      return  ((UserCompany) user).getId();
+    if (sessionServer.getUserPerson()!=null) {
+      this.userId = sessionServer.getUserPerson().getId();
+    } else if (sessionServer.getUserCompany()!=null) {
+      this.userId =  sessionServer.getUserCompany().getId();
     } else {
       throw new BunqException(ERROR_UNEXPECTED_USER_TYPE);
     }
@@ -70,23 +66,16 @@ public class SessionContext implements java.io.Serializable {
     Date expiryTime = new Date();
     long sessionTimeoutMilliseconds = getSessionTimeout(sessionServer) * MILLISECONDS_IN_SECOND;
     expiryTime.setTime(expiryTime.getTime() + sessionTimeoutMilliseconds);
-
     return expiryTime;
   }
 
   private static int getSessionTimeout(SessionServer sessionServer) {
-    UserCompany userCompany = sessionServer.getUserCompany();
-
-    if (userCompany != null) {
-      return userCompany.getSessionTimeout();
+    if (sessionServer.getUserCompany() != null) {
+      return sessionServer.getUserCompany().getSessionTimeout();
     }
-
-    UserPerson userPerson = sessionServer.getUserPerson();
-
-    if (userPerson != null) {
-      return userPerson.getSessionTimeout();
+    if (sessionServer.getUserPerson() != null) {
+      return sessionServer.getUserPerson().getSessionTimeout();
     }
-
     return SESSION_TIMEOUT_DEFAULT;
   }
 
@@ -100,9 +89,5 @@ public class SessionContext implements java.io.Serializable {
 
   public Integer getUserId() {
     return userId;
-  }
-
-  public UserContext initUserContext() {
-    return new UserContext(getUserId());
   }
 }

--- a/src/main/java/com/bunq/sdk/context/SessionContext.java
+++ b/src/main/java/com/bunq/sdk/context/SessionContext.java
@@ -102,4 +102,7 @@ public class SessionContext implements java.io.Serializable {
     return userId;
   }
 
+  public UserContext initUserContext() {
+    return new UserContext(getUserId());
+  }
 }

--- a/src/main/java/com/bunq/sdk/context/SessionContext.java
+++ b/src/main/java/com/bunq/sdk/context/SessionContext.java
@@ -12,7 +12,7 @@ import java.util.Date;
 /**
  * Context of your current bunq Public API session.
  */
-class SessionContext implements java.io.Serializable {
+public class SessionContext implements java.io.Serializable {
 
   /**
    * Error constants.

--- a/src/main/java/com/bunq/sdk/context/UserContext.java
+++ b/src/main/java/com/bunq/sdk/context/UserContext.java
@@ -17,14 +17,14 @@ public class UserContext {
   private static final String ERROR_UNEXPECTED_USER_INSTANCE = "\"%s\" is unexpected user instance.";
   private static final String ERROR_NO_ACTIVE_MONETARY_ACCOUNT_FOUND = "No active monetary account found.";
 
+  private final ApiContext apiContext;
   private final UserCompany userCompany;
   private final UserPerson userPerson;
   private final MonetaryAccountBank primaryMonetaryAccountBank;
-  private final Integer userId;
 
   public UserContext(ApiContext apiContext) {
-    this.userId = apiContext.getSessionContext().getUserId();
-    User user = User.getFirst(apiContext);
+    this.apiContext = apiContext;
+    User user = User.getFirst(this.apiContext);
     if (user.getUserPerson()!=null) {
       this.userPerson = user.getUserPerson();
       this.userCompany = null;
@@ -34,7 +34,7 @@ public class UserContext {
     } else {
       throw new BunqException(ERROR_UNEXPECTED_USER_INSTANCE);
     }
-    MonetaryAccountBank monetaryAccountBank = MonetaryAccountBank.getFirstActive(apiContext);
+    MonetaryAccountBank monetaryAccountBank = MonetaryAccountBank.getFirstActive(this.apiContext);
     if(monetaryAccountBank!=null) {
       this.primaryMonetaryAccountBank = monetaryAccountBank;
     }
@@ -43,8 +43,12 @@ public class UserContext {
     }
   }
 
+  public ApiContext getApiContext() {
+    return apiContext;
+  }
+
   public Integer getUserId() {
-    return this.userId;
+    return this.apiContext.getSessionContext().getUserId();
   }
 
   public boolean isOnlyUserPersonSet() {

--- a/src/main/java/com/bunq/sdk/model/generated/endpoint/MonetaryAccountBank.java
+++ b/src/main/java/com/bunq/sdk/model/generated/endpoint/MonetaryAccountBank.java
@@ -1,5 +1,7 @@
 package com.bunq.sdk.model.generated.endpoint;
 
+import com.bunq.sdk.context.ApiContext;
+import com.bunq.sdk.exception.BunqException;
 import com.bunq.sdk.http.ApiClient;
 import com.bunq.sdk.http.BunqResponse;
 import com.bunq.sdk.http.BunqResponseRaw;
@@ -48,6 +50,7 @@ public class MonetaryAccountBank extends BunqModel {
   public static final String FIELD_REASON_DESCRIPTION = "reason_description";
   public static final String FIELD_NOTIFICATION_FILTERS = "notification_filters";
   public static final String FIELD_SETTING = "setting";
+  private static final String MONETARY_ACCOUNT_STATUS_ACTIVE = "ACTIVE";
 
   /**
    * Object type.
@@ -405,13 +408,33 @@ public class MonetaryAccountBank extends BunqModel {
   }
 
   /**
+   * Gets the first active MonetaryAccountBank or null
+   */
+  public static MonetaryAccountBank getFirstActive(ApiContext apiContext) {
+    List<MonetaryAccountBank> allMonetaryAccount = list(apiContext, null,null).getValue();
+    for (MonetaryAccountBank monetaryAccountBank : allMonetaryAccount) {
+      if (monetaryAccountBank.getStatus().equals(MONETARY_ACCOUNT_STATUS_ACTIVE)) {
+        return monetaryAccountBank;
+      }
+    }
+    return null;
+  }
+
+  /**
    * Gets a listing of all MonetaryAccountBanks of a given user.
    */
-  public static BunqResponse<List<MonetaryAccountBank>> list(Map<String, String> params, Map<String, String> customHeaders) {
-    ApiClient apiClient = new ApiClient(getApiContext());
+  private static BunqResponse<List<MonetaryAccountBank>> list(ApiContext apiContext, Map<String, String> params, Map<String, String> customHeaders) {
+    ApiClient apiClient = new ApiClient(apiContext);
     BunqResponseRaw responseRaw = apiClient.get(String.format(ENDPOINT_URL_LISTING, determineUserId()), params, customHeaders);
 
     return fromJsonList(MonetaryAccountBank.class, responseRaw, OBJECT_TYPE_GET);
+  }
+
+  /**
+   * Gets a listing of all MonetaryAccountBanks of a given user.
+   */
+  public static BunqResponse<List<MonetaryAccountBank>> list(Map<String, String> params, Map<String, String> customHeaders) {
+    return list(getApiContext(),params,customHeaders);
   }
 
   public static BunqResponse<List<MonetaryAccountBank>> list() {

--- a/src/main/java/com/bunq/sdk/model/generated/endpoint/User.java
+++ b/src/main/java/com/bunq/sdk/model/generated/endpoint/User.java
@@ -1,5 +1,6 @@
 package com.bunq.sdk.model.generated.endpoint;
 
+import com.bunq.sdk.context.ApiContext;
 import com.bunq.sdk.exception.BunqException;
 import com.bunq.sdk.http.ApiClient;
 import com.bunq.sdk.http.BunqResponse;
@@ -72,10 +73,21 @@ public class User extends BunqModel implements AnchorObjectInterface {
   }
 
   /**
+   * Get first of all available users.
+   */
+  public static User getFirst(ApiContext apiContext) {
+    return list(apiContext,null,null).getValue().get(0);
+  }
+
+  /**
    * Get a collection of all available users.
    */
   public static BunqResponse<List<User>> list(Map<String, String> params, Map<String, String> customHeaders) {
-    ApiClient apiClient = new ApiClient(getApiContext());
+    return list(getApiContext(),params,customHeaders);
+  }
+
+  private static BunqResponse<List<User>> list(ApiContext apiContext,Map<String, String> params, Map<String, String> customHeaders) {
+    ApiClient apiClient = new ApiClient(apiContext);
     BunqResponseRaw responseRaw = apiClient.get(ENDPOINT_URL_LISTING, params, customHeaders);
 
     return fromJsonList(User.class, responseRaw);

--- a/src/test/java/com/bunq/sdk/context/UserContextTest.java
+++ b/src/test/java/com/bunq/sdk/context/UserContextTest.java
@@ -1,0 +1,19 @@
+package com.bunq.sdk.context;
+
+import com.bunq.sdk.BunqSdkTestBase;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class UserContextTest extends BunqSdkTestBase {
+
+    @Test
+    public void testConstruct() {
+        ApiContext context = getApiContext();
+
+        UserContext sut = new UserContext(context);
+
+        assertNotNull(sut.getUserId());
+        assertNotNull(sut.getMainMonetaryAccountId());
+    }
+}


### PR DESCRIPTION
a smaller change towards #93 

this change enables creation of the userContext based on the sessionContext so it can be used outside the static context of BunqContext

the required change is to add the public modifier onto the SessionContext class to expose it's public methods correctly outside the package