### PR TITLE
Update version to 1.28.0.2 and include jitpack.yml so that build doesnt fail on tests which are dependant on a backend

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.bunq.sdk'
-version '1.28.0.1'
+version '1.28.0.2'
 
 apply plugin: 'java'
 apply plugin: 'maven-publish'

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+jdk:
+  - openjdk17
+skip:
+  - test


### PR DESCRIPTION
Update version to 1.28.0.2 and include jitpack.yml so that build doesnt fail on tests which are dependant on a backend